### PR TITLE
ssp: gather CNV templates

### DIFF
--- a/gather_cnv
+++ b/gather_cnv
@@ -35,4 +35,7 @@ done
 # Collect VMs details
 /usr/bin/gather_cnv_vms_details
 
+# Collect SSP details
+/usr/bin/gather_cnv_ssp
+
 exit 0

--- a/gather_cnv_ssp
+++ b/gather_cnv_ssp
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+BASE_COLLECTION_PATH="/must-gather"
+
+# we expect the CNV templates to be deployed only in the `opneshift` namespace. But if this turns out not to be true, we need to know.
+for ocproject in $(/usr/bin/oc get templates --all-namespaces -l 'template.kubevirt.io/type=base' -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' | uniq)
+do
+  templates_collection_path=${BASE_COLLECTION_PATH}/namespaces/${ocproject}/templates
+
+  mkdir -p ${templates_collection_path}
+
+  /usr/bin/oc get templates -n ${ocproject} -o yaml > ${templates_collection_path}/${ocproject}.yaml
+done
+
+exit 0


### PR DESCRIPTION
We intentionally look in all the namespaces, even though
we expect to have them in the `openshift` namespaces, to get
a clue about weird states (e.g. duplicated or misplaced templates)

Signed-off-by: Francesco Romani <fromani@redhat.com>