### PR TITLE
Collect journal logs on nodes

### DIFF
--- a/gather_cnv_nodes
+++ b/gather_cnv_nodes
@@ -36,5 +36,15 @@ do
     oc exec -it $pod -n node-gather -- brctl show >> $NODE_PATH/bridge
 done
 
+# Collect journal logs for specified units for all nodes
+NODE_UNITS=(NetworkManager kubelet)
+for NODE in $(oc get nodes --no-headers -o custom-columns=':metadata.name'); do
+    NODE_PATH=${NODES_PATH}/$NODE/
+    mkdir -p ${NODE_PATH}
+    for UNIT in ${NODE_UNITS[@]}; do
+        oc adm node-logs $NODE -u $UNIT > ${NODE_PATH}/${NODE}_logs_$UNIT &
+    done
+done
+
 oc delete -f $DAEMONSET_MANIFEST
 oc delete -f $CRD_MANIFEST


### PR DESCRIPTION
Gather NetworkManager journal from nodes.
Logs for additional units can be collected by adding them to NODE_UNITS